### PR TITLE
[Reviewer Ellie] Add open source attribution for monotonic.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -827,3 +827,7 @@ License: MIT (https://github.com/docopt/docopt/blob/463d780a698cbacb1cf5590ae849
 A.57 prctl
 Copyright (c) 2005-2010 Slide, Inc
 License: BSD (https://github.com/slideinc/prctl/blob/master/LICENSE)
+
+A.58 monotonic
+Copyright 2014-2016 Ori Livnehi, <ori@wikimedia.org>
+License: Apache 2.0 (https://github.com/atdt/monotonic/blob/master/LICENSE)


### PR DESCRIPTION
This is a backport of Python's monotonic time function to Python2.7.

I'd like to check that I haven't missed anything crucial here.