### PR TITLE
[Reviewer: RJW2] Added licence for python module idna

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2573,3 +2573,85 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+A.85 idna
+
+Source: https://github.com/kjd/idna/blob/v2.5/LICENSE.rst
+
+Copyright (c) 2013-2017, Kim Davies. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+#. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+#. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with
+   the distribution.
+
+#. Neither the name of the copyright holder nor the names of the 
+   contributors may be used to endorse or promote products derived 
+   from this software without specific prior written permission.
+
+#. THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS "AS IS" AND ANY
+   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR 
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+   DAMAGE.
+
+Portions of the codec implementation and unit tests are derived from the
+Python standard library, which carries the `Python Software Foundation
+License <https://docs.python.org/2/license.html>`_:
+
+   Copyright (c) 2001-2014 Python Software Foundation; All Rights Reserved
+
+Portions of the unit tests are derived from the Unicode standard, which 
+is subject to the Unicode, Inc. License Agreement:
+
+   Copyright (c) 1991-2014 Unicode, Inc. All rights reserved.
+   Distributed under the Terms of Use in 
+   <http://www.unicode.org/copyright.html>.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of the Unicode data files and any associated documentation
+   (the "Data Files") or Unicode software and any associated documentation
+   (the "Software") to deal in the Data Files or Software
+   without restriction, including without limitation the rights to use,
+   copy, modify, merge, publish, distribute, and/or sell copies of
+   the Data Files or Software, and to permit persons to whom the Data Files
+   or Software are furnished to do so, provided that
+   
+   (a) this copyright and permission notice appear with all copies 
+   of the Data Files or Software,
+
+   (b) this copyright and permission notice appear in associated 
+   documentation, and
+
+   (c) there is clear notice in each modified Data File or in the Software
+   as well as in the documentation associated with the Data File(s) or
+   Software that the data or software has been modified.
+
+   THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+   ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+   WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+   IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+   NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+   DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+   DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+   TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+   PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+   Except as contained in this notice, the name of a copyright holder
+   shall not be used in advertising or otherwise to promote the sale,
+   use or other dealings in these Data Files or Software without prior
+   written authorization of the copyright holder.


### PR DESCRIPTION
Hi Richard.

This PR adds the the missing licence for the python modules 'idna' included by PC. The module is included here: https://github.com/Metaswitch/crest/blob/dev/crest-requirements.txt.

I wanted to assign this to Krista but she isn't present under the "Reviewers" drop-down. Could I assign it to you instead? I will link her the PR so that she can sign it off.